### PR TITLE
Eviter de dépasser le nombre de requêtes simultanées. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,20 @@ const options = {
 };
 (new ReviewAppManager(scalingoToken, scalingoApiUrl, options)).startEcoMode();
 ```
+
+### Status Poll 
+
+The Scalingo API limits the numbers of applications scaling in the same time. 
+
+To deal with this limit, a mechanism of polling by application scaling is set up.
+
+By default, the scaling status of each application is checked every 1000ms with a maximum of 10 attempts. 
+These values can be parameterized in the options object of the `ReviewAppManager` constructor : `pollTimeInterval` (number, in ms) and `pollMaxAttempts` (number).
+
+```javascript
+const options = {
+  pollTimeInterval: 1000,
+  pollMaxAttempts: 10
+};
+(new ReviewAppManager(scalingoToken, scalingoApiUrl, options)).startEcoMode();
+```

--- a/lib/ReviewAppClient.js
+++ b/lib/ReviewAppClient.js
@@ -8,6 +8,8 @@ class ReviewAppClient {
   _scalingoToken = null;
   _scalingoApiUrl = null;
   _ignoredReviewApps = null;
+  _pollTimeInterval = null;
+  _pollMaxAttempts = null;
 
   // Internals
   _client = null;
@@ -19,10 +21,12 @@ class ReviewAppClient {
       || ((new Date()).getTime() > this._expirationDate.getTime());
   }
 
-  constructor(scalingToken, scalingoApiUrl, ignoredReviewApps = []) {
+  constructor(scalingToken, scalingoApiUrl, ignoredReviewApps = [], pollTimeInterval, pollMaxAttempts) {
     this._scalingoToken = scalingToken;
     this._scalingoApiUrl = scalingoApiUrl;
     this._ignoredReviewApps = ignoredReviewApps;
+    this._pollTimeInterval = pollTimeInterval;
+    this._pollMaxAttempts = pollMaxAttempts;
   }
 
   async getClient() {
@@ -36,11 +40,14 @@ class ReviewAppClient {
   async scale(app, formation) {
     const scalingoClient = await this.getClient();
     console.debug(`Scaling app ${app.name} to ${formation[0].amount} container(s)…`);
+
     try {
-      await scalingoClient.Containers.scale(app.name, formation);
+      const { operation } = await scalingoClient.Containers.scale(app.name, formation);
+
+      await this.pollOperationStatus({ operation, interval, maxAttempts });
       console.log(`App ${app.name} scaled successfully`);
     } catch (err) {
-      if (err._data && err._data.error === 'no change in containers formation') {
+      if ((err._data && err._data.error === 'no change in containers formation') || err === 'no change in containers formation') {
         console.log(`App ${app.name} not scaled due to unchanged formation.`);
       } else {
         console.error(err);
@@ -70,6 +77,27 @@ class ReviewAppClient {
       return this.scale(app, [{ name: 'web', size: 'S', amount: 1 }]);
     }));
   }
+
+  async pollOperationStatus({ operation, interval, maxAttempts }) {
+    let attempts = 0;
+
+    const executePoll = async (resolve, reject) => {
+      attempts++;
+      await operation.refresh();
+
+      if (operation.status === 'done') {
+        return resolve();
+      } else if (operation.status === 'error') {
+        return reject(new Error(operation.error));
+      } else if (attempts >= this._pollMaxAttempts) {
+        return reject(new Error('Exceeded max attempts'));
+      } else {
+        setTimeout(executePoll, interval, resolve, reject);
+      }
+    };
+
+    return new Promise(executePoll);
+  };
 
 }
 

--- a/lib/ReviewAppClient.js
+++ b/lib/ReviewAppClient.js
@@ -44,7 +44,7 @@ class ReviewAppClient {
     try {
       const { operation } = await scalingoClient.Containers.scale(app.name, formation);
 
-      await this.pollOperationStatus({ operation, interval, maxAttempts });
+      await this.pollOperationStatus(operation);
       console.log(`App ${app.name} scaled successfully`);
     } catch (err) {
       if ((err._data && err._data.error === 'no change in containers formation') || err === 'no change in containers formation') {
@@ -78,7 +78,7 @@ class ReviewAppClient {
     }));
   }
 
-  async pollOperationStatus({ operation, interval, maxAttempts }) {
+  async pollOperationStatus(operation) {
     let attempts = 0;
 
     const executePoll = async (resolve, reject) => {
@@ -92,7 +92,7 @@ class ReviewAppClient {
       } else if (attempts >= this._pollMaxAttempts) {
         return reject(new Error('Exceeded max attempts'));
       } else {
-        setTimeout(executePoll, interval, resolve, reject);
+        setTimeout(executePoll, this._pollTimeInterval, resolve, reject);
       }
     };
 

--- a/lib/ReviewAppManager.js
+++ b/lib/ReviewAppManager.js
@@ -8,7 +8,9 @@ class ReviewAppManager {
 
   constructor(scalingToken, scalingoApiUrl, options = {}) {
     const ignoredReviewApps = options.ignoredReviewApps || [];
-    this._reviewAppClient = new ReviewAppClient(scalingToken, scalingoApiUrl, ignoredReviewApps);
+    const pollTimeInterval = options.pollTimeInterval || 1000;
+    const pollMaxAttempts = options.pollMaxAttempts || 10;
+    this._reviewAppClient = new ReviewAppClient(scalingToken, scalingoApiUrl, ignoredReviewApps, pollTimeInterval, pollMaxAttempts);
 
     const stopCronTime = options.stopCronTime || '0 0 19 * * 1-5';
     const restartCronTime = options.restartCronTime || '0 0 8 * * 1-5';


### PR DESCRIPTION
## Problème 
Il se peut quand il y a trop d'opération de scaling en même temps que cela dépasse le quota autorisé. 
Voir cette [issue](https://github.com/1024pix/pix-bot/issues/4).

## Solution 
Ajouter une méthode `pollOperationStatus` qui vérifie le statut de l'opération de scaling en cours.
Cette méthode utilise a des valeurs par défaut pour le `pollTimeInterval` et le `pollMaxAttempts`. On peut aussi définir ses valeurs dans les `options`  passé à l'initialisation de `ReviewAppManager`. 



  