### PR TITLE
Corriger une erreur d'écriture. 

### DIFF
--- a/lib/ReviewAppClient.js
+++ b/lib/ReviewAppClient.js
@@ -21,8 +21,8 @@ class ReviewAppClient {
       || ((new Date()).getTime() > this._expirationDate.getTime());
   }
 
-  constructor(scalingToken, scalingoApiUrl, ignoredReviewApps = [], pollTimeInterval, pollMaxAttempts) {
-    this._scalingoToken = scalingToken;
+  constructor(scalingoToken, scalingoApiUrl, ignoredReviewApps = [], pollTimeInterval, pollMaxAttempts) {
+    this._scalingoToken = scalingoToken;
     this._scalingoApiUrl = scalingoApiUrl;
     this._ignoredReviewApps = ignoredReviewApps;
     this._pollTimeInterval = pollTimeInterval;

--- a/lib/ReviewAppManager.js
+++ b/lib/ReviewAppManager.js
@@ -6,11 +6,11 @@ class ReviewAppManager {
   _reviewAppClient = null;
   _jobManager = null;
 
-  constructor(scalingToken, scalingoApiUrl, options = {}) {
+  constructor(scalingoToken, scalingoApiUrl, options = {}) {
     const ignoredReviewApps = options.ignoredReviewApps || [];
     const pollTimeInterval = options.pollTimeInterval || 1000;
     const pollMaxAttempts = options.pollMaxAttempts || 10;
-    this._reviewAppClient = new ReviewAppClient(scalingToken, scalingoApiUrl, ignoredReviewApps, pollTimeInterval, pollMaxAttempts);
+    this._reviewAppClient = new ReviewAppClient(scalingoToken, scalingoApiUrl, ignoredReviewApps, pollTimeInterval, pollMaxAttempts);
 
     const stopCronTime = options.stopCronTime || '0 0 19 * * 1-5';
     const restartCronTime = options.restartCronTime || '0 0 8 * * 1-5';


### PR DESCRIPTION
Il y a une erreur d'écriture à un nom de variable. 
`scalingToken` au lieu de `scalingoToken`. 