### PR TITLE
Add time zone support for cron jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ const options = {
 (new ReviewAppManager(scalingoToken, scalingoApiUrl, options)).startEcoMode();
 ```
 
-### Status Poll 
+### Scalingo pending operations limit management
 
 The Scalingo API limits the numbers of applications scaling in the same time. 
 
@@ -62,6 +62,19 @@ These values can be parameterized in the options object of the `ReviewAppManager
 const options = {
   pollTimeInterval: 1000,
   pollMaxAttempts: 10
+};
+(new ReviewAppManager(scalingoToken, scalingoApiUrl, options)).startEcoMode();
+```
+
+### Specifying cron jobs time zone
+
+By default, the cron jobs are based on UTC server's local time zone.
+
+You can set up a specific time zone with the `timeZone` option, cf. [the list of available time zones](https://github.com/eggert/tz/blob/c7cc14a846e1dcaa2800f3f0070a12fd514f608c/zone.tab).
+
+```javascript
+const options = {
+  timeZone: 'Europe/Paris',
 };
 (new ReviewAppManager(scalingoToken, scalingoApiUrl, options)).startEcoMode();
 ```

--- a/examples/index.js
+++ b/examples/index.js
@@ -9,8 +9,15 @@ async function main() {
   const stopCronTime = process.env.STOP_CRON_TIME;
   const restartCronTime = process.env.RESTART_CRON_TIME;
   const ignoredReviewApps = process.env.IGNORED_REVIEW_APPS.split(',');
+  const timeZone = process.env.TIME_ZONE;
 
-  const reviewAppManager = new ReviewAppManager(scalingoToken, scalingoApiUrl, { stopCronTime, restartCronTime, ignoredReviewApps });
+  const reviewAppManager = new ReviewAppManager(scalingoToken, scalingoApiUrl, {
+    stopCronTime,
+    restartCronTime,
+    ignoredReviewApps,
+    timeZone
+  });
+
   return reviewAppManager.startEcoMode();
 }
 

--- a/lib/Job.js
+++ b/lib/Job.js
@@ -2,9 +2,9 @@ const CronJob = require('cron').CronJob;
 
 class Job {
 
-  constructor(name, cronTime, onTick) {
+  constructor(name, cronTime, onTick, options = {}) {
     this.name = name;
-    this.cron = new CronJob(cronTime, onTick, null, false, 'Europe/Paris');
+    this.cron = new CronJob(cronTime, onTick, null, false, options.timeZone);
   }
 
   start() {

--- a/lib/JobManager.js
+++ b/lib/JobManager.js
@@ -3,9 +3,10 @@ const Job = require('./Job');
 class JobManager {
 
   // Params
-  _reviewAppClient = null;
-  _stopCronTime = null;
-  _restartCronTime = null;
+  _reviewAppClient;
+  _stopCronTime;
+  _restartCronTime;
+  _timeZone;
 
   // Internals
   _jobs = [];
@@ -14,14 +15,15 @@ class JobManager {
     this._reviewAppClient = reviewAppClient;
     this._stopCronTime = options.stopCronTime || '0 0 19 * * 1-5';
     this._restartCronTime = options.restartCronTime || '0 0 8 * * 1-5';
+    this._timeZone = options.timeZone;
 
     const stopJob = new Job('stop-managed-review-apps', this._stopCronTime, async () => {
       return await this._reviewAppClient.stopAllReviewApps();
-    });
+    }, { timeZone: this._timeZone });
 
-    const restartJob =  new Job('restart-managed-review-apps', this._restartCronTime, async () => {
+    const restartJob = new Job('restart-managed-review-apps', this._restartCronTime, async () => {
       return await this._reviewAppClient.restartAllReviewApps();
-    });
+    }, { timeZone: this._timeZone });
 
     this._jobs.push(stopJob, restartJob);
   }

--- a/test/Job.test.js
+++ b/test/Job.test.js
@@ -6,12 +6,12 @@ describe('Job', () => {
 
   describe('#constructor', () => {
 
-    it('should keep an internal reference on given parameters', () => {
-      // given
-      const name = 'my-job';
-      const cronTime = '0 30 20 * * 1-5';
-      const onTick = () => {};
+    const name = 'my-job';
+    const cronTime = '0 30 20 * * 1-5';
+    const onTick = () => {
+    };
 
+    it('should keep an internal reference on given parameters', () => {
       // when
       const job = new Job(name, cronTime, onTick);
 
@@ -19,7 +19,26 @@ describe('Job', () => {
       expect(job.name).to.equal(name);
       expect(job.cron).to.be.an.instanceof(CronJob);
       expect(job.cron.cronTime.source).to.equal(cronTime);
+      expect(job.cron.cronTime.zone).to.be.undefined;
+    });
+
+    it('should accept a valid time zone option', () => {
+      // when
+      const job = new Job(name, cronTime, onTick, { timeZone: 'Europe/Paris' });
+
+      // then
       expect(job.cron.cronTime.zone).to.equal('Europe/Paris');
+    });
+
+    it('should fail when given an invalid time zone option', () => {
+      try {
+        // when
+        new Job(name, cronTime, onTick, { timeZone: 'Invalid/Timezone' });
+        expect.fail('an error to be thrown but was not');
+      } catch (e) {
+        // then
+        expect(e.message).to.equal('Invalid timezone.');
+      }
     });
   });
 
@@ -28,7 +47,8 @@ describe('Job', () => {
     it('should start each job manager’s tasks', () => {
       // given
       const cronJob = { start: sinon.stub() };
-      const job = new Job('my-job', '0 30 20 * * 1-5', () => {});
+      const job = new Job('my-job', '0 30 20 * * 1-5', () => {
+      });
       job.cron = cronJob;
 
       // when
@@ -44,7 +64,8 @@ describe('Job', () => {
     it('should stop each job manager’s tasks', () => {
       // given
       const cronJob = { stop: sinon.stub() };
-      const job = new Job('my-job', '0 30 20 * * 1-5', () => {});
+      const job = new Job('my-job', '0 30 20 * * 1-5', () => {
+      });
       job.cron = cronJob;
 
       // when

--- a/test/JobManager.test.js
+++ b/test/JobManager.test.js
@@ -15,14 +15,16 @@ describe('JobManager', () => {
       const reviewAppClient = { stubbed: 'reviewAppClient' };
       const stopCronTime = '0 30 20 * * 1-5';
       const restartCronTime = '0 30 7 * * 1-5';
+      const timeZone = 'Europe/Paris';
 
       // when
-      const jobManager = new JobManager(reviewAppClient, { stopCronTime, restartCronTime });
+      const jobManager = new JobManager(reviewAppClient, { stopCronTime, restartCronTime, timeZone });
 
       // then
       expect(jobManager._reviewAppClient).to.deep.equal(reviewAppClient);
       expect(jobManager._stopCronTime).to.deep.equal(stopCronTime);
       expect(jobManager._restartCronTime).to.deep.equal(restartCronTime);
+      expect(jobManager._timeZone).to.deep.equal(timeZone);
     });
 
     it('should manage a cron job to stop review apps', () => {


### PR DESCRIPTION
Close #5 

Add the possibility to define a specific cron jobs time zone.

By default, it is the local one of the server.
