### PR TITLE
[TECH] Mise a jour de Scalingo de 0.1.1 vers 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -426,11 +426,11 @@
       "dev": true
     },
     "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "1.5.10"
+        "follow-redirects": "^1.10.0"
       }
     },
     "balanced-match": {
@@ -666,14 +666,6 @@
         }
       }
     },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -806,12 +798,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "requires": {
-        "debug": "=3.1.0"
-      }
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.3.tgz",
+      "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -1393,11 +1382,6 @@
         "moment": ">= 2.9.0"
       }
     },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-    },
     "nise": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
@@ -1917,13 +1901,13 @@
       "dev": true
     },
     "scalingo": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/scalingo/-/scalingo-0.1.1.tgz",
-      "integrity": "sha512-IIDvRKwS6uVAOdgyS5a3RWOTMTFMTo2vCVWX3OxcfHvYXgZ/51c2byEletnZ/39d7IRz7ze+BciY9m98RMLanQ==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/scalingo/-/scalingo-0.3.1.tgz",
+      "integrity": "sha512-I9M/5lT04O1TAIIv5B498e+IN9ACE2XeH1RzBGhUK2lXPb2Ds2HdbYTefDuDncwwSHhnkQJ/c6wZF+pj/nL5RQ==",
       "requires": {
-        "axios": "0.19.x",
+        "axios": "^0.21.1",
         "isomorphic-ws": "4.x",
-        "ws": "7.x"
+        "ws": "^7.4.3"
       }
     },
     "semver": {
@@ -2273,9 +2257,9 @@
       }
     },
     "ws": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.1.tgz",
-      "integrity": "sha512-sucePNSafamSKoOqoNfBd8V0StlkzJKL2ZAhGQinCfNQ+oacw+Pk7lcdAElecBF2VkLNZRiIb5Oi1Q5lVUVt2A=="
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
+      "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "cron": "^1.8.2",
-    "scalingo": "^0.1.1"
+    "scalingo": "^0.3.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Dependabot identifie une version vulnérable d'axios, conseillant de la mettre vers la 0.21.1.
Nous avons remarqué que c'est le package scalingo qui importe axios et que celui ci bénéficiait d'une mise a jour, mettant ainsi a jour axios vers la dernière version.