### PR TITLE
Add the app name when logging the error

### DIFF
--- a/lib/ReviewAppClient.js
+++ b/lib/ReviewAppClient.js
@@ -83,7 +83,7 @@ class ReviewAppClient {
       if ((err._data && err._data.error === 'no change in containers formation') || err === 'no change in containers formation') {
         console.log(`App ${app.name} not scaled due to unchanged formation.`);
       } else {
-        console.error(err);
+        console.error(app.name, err);
         throw err;
       }
     }


### PR DESCRIPTION
Il est impossible de savoir actuellement quelle application a eu un problème de scaling en cas d'erreur. Cela corrige ceci.