### PR TITLE
[BUGFIX] Handle expected Scalingo  API errors and throw an error otherwise

### DIFF
--- a/lib/ReviewAppClient.js
+++ b/lib/ReviewAppClient.js
@@ -95,6 +95,7 @@ class ReviewAppClient {
         console.log(`App ${app.name} not scaled due to unchanged formation.`);
       } else {
         console.error(app.name, err);
+        throw err;
       }
     }
   }

--- a/lib/ReviewAppClient.js
+++ b/lib/ReviewAppClient.js
@@ -93,6 +93,8 @@ class ReviewAppClient {
     } catch (err) {
       if ((err._data && err._data.error === 'no change in containers formation') || err === 'no change in containers formation') {
         console.log(`App ${app.name} not scaled due to unchanged formation.`);
+      } if (err.status === 422) {
+        console.log(app.name, err);
       } else {
         console.error(app.name, err);
         throw err;

--- a/test/testing.js
+++ b/test/testing.js
@@ -8,9 +8,21 @@ const expect = chai.expect;
 const nock = require('nock');
 nock.disableNetConnect();
 
+function catchErr(promiseFn, ctx) {
+  return async (...args) => {
+    try {
+      await promiseFn.call(ctx, ...args);
+      return 'should have thrown an error';
+    } catch (err) {
+      return err;
+    }
+  };
+}
+
 module.exports = {
   chai,
   expect,
   nock,
   sinon,
+  catchErr,
 };


### PR DESCRIPTION
Some errors are due to scaling issue (when the app is booting for example), that we can safety ignore. But some are unrelated, such as strange 404 errors, and we want to react to them.