### PR TITLE
[DRAFT] Delay review app restart by 3000 ms by default

### DIFF
--- a/lib/ReviewAppClient.js
+++ b/lib/ReviewAppClient.js
@@ -11,6 +11,7 @@ class ReviewAppClient {
   _ignoredReviewApps = null;
   _pollTimeInterval = null;
   _pollMaxAttempts = null;
+  _reviewAppRestartDelay = null;
 
   // Internals
   _client = null;
@@ -23,6 +24,7 @@ class ReviewAppClient {
     this._ignoredReviewApps = options.ignoredReviewApps || [];
     this._pollTimeInterval = options.pollTimeInterval || 1000;
     this._pollMaxAttempts = options.pollMaxAttempts || 10;
+    this._reviewAppRestartDelay = options.reviewAppRestartDelay || 3000;
   }
 
   /*
@@ -113,9 +115,14 @@ class ReviewAppClient {
 
   async restartAllReviewApps() {
     const activeReviewApps = await this._getReviewsApps();
-    return Promise.all(activeReviewApps.map(async (app) => {
-      return this.scale(app, [{ name: 'web', size: 'S', amount: 1 }]);
-    }));
+    const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    const result = [];
+    for (const app of activeReviewApps) {
+      result.push(this.scale(app, [{name: 'web', size: 'S', amount: 1}]));
+      await delay(this._reviewAppRestartDelay);
+    }
+    return result;
   }
 }
 

--- a/test/ReviewAppClient.test.js
+++ b/test/ReviewAppClient.test.js
@@ -406,7 +406,7 @@ describe('ReviewAppClient', () => {
           }
         });
 
-      const reviewAppClient = new ReviewAppClient(scalingoToken, scalingoApiUrl);
+      const reviewAppClient = new ReviewAppClient(scalingoToken, scalingoApiUrl, { reviewAppRestartDelay: 1 });
 
       // when
       await reviewAppClient.restartAllReviewApps();


### PR DESCRIPTION
## :christmas_tree: Problème
Scalingo nous a informé dans un e-mail que le redémarrage de nos conteneurs tous les matins était brutal et levait des alertes chez eux (création de 200 à 300 RA en simultané).   

## :gift: Proposition
La solution la plus simple et rapide à mettre en place consiste à ajouter un délai entre chaque requête de redémarrage. Ce délai est fixé arbitrairement à 3 secondes mais peut être discuté. 

## :socks: Remarques
La solution optimale qui va être étudiée serait de ne redémarrer une RA qu'au moment d'une première requête sur celle-ci.
