### PR TITLE
[TECH] Ne pas définir la taille du conteneur lorsqu'on scale une review app

### DIFF
--- a/lib/ReviewAppClient.js
+++ b/lib/ReviewAppClient.js
@@ -109,7 +109,7 @@ class ReviewAppClient {
     const apps = await this._getReviewsApps();
     const activeReviewApps = apps.filter((app) => app.status === 'new' || app.status === 'running');
     return Promise.all(activeReviewApps.map(async (app) => {
-      await this.scale(app, [{ name: 'web', size: 'S', amount: 0 }])
+      await this.scale(app, [{ name: 'web', amount: 0 }])
     }));
   }
 
@@ -119,7 +119,7 @@ class ReviewAppClient {
 
     const result = [];
     for (const app of activeReviewApps) {
-      result.push(this.scale(app, [{name: 'web', size: 'S', amount: 1}]));
+      result.push(this.scale(app, [{name: 'web', amount: 1}]));
       await delay(this._reviewAppRestartDelay);
     }
     return result;

--- a/test/ReviewAppClient.test.js
+++ b/test/ReviewAppClient.test.js
@@ -23,7 +23,7 @@ describe('ReviewAppClient', () => {
   describe('#scale()', () => {
 
     const app = { name: 'my-review-app' };
-    const formation = [{ name: 'web', size: 'S', amount: 0 }];
+    const formation = [{ name: 'web', amount: 0 }];
 
     it('should call Scalingo API through the Scalingo client `Containers` services', async () => {
       // given


### PR DESCRIPTION
## :unicorn: Problème
Actuellement, lors du scaling des review-apps qui est effectué tous les soirs et matins, nous forçons la taille du conteneur à S. Cependant, certaines RA comme celles de pix-airflow ont besoin de s'exécuter sur des conteneurs plus volumineux. 

## :robot: Proposition
Ne pas définir la taille du conteneur lorsqu'on scale une review app

## :rainbow: Remarques
La documentation de Scalingo nous informe que ce champ est optionnel et que, s'il n'est pas défini, la taille du conteneur restera inchangée:
![Screenshot from 2024-09-19 11-07-03](https://github.com/user-attachments/assets/75250466-cfcf-4ba7-9426-ebb6eaf44a46)