### PR TITLE
[TECH] Mettre à jour la branche pour le workflow de release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     branches:
-      - master
+      - main
   repository_dispatch:
     types: ['deploy']
   workflow_dispatch:


### PR DESCRIPTION
## :unicorn: Problème
Le workflow de release ne fonctionne pas avec la branche master (voir config du workflow). La branche principale a donc été renommée en main mais l'action se base toujours sur la branche master.

## :robot: Proposition
Remplacer la branche master par main pour le workflow de release.