### PR TITLE
[TECH] Ajouter le nom de l'application dans certains messages d'erreur

### DIFF
--- a/lib/ReviewAppClient.js
+++ b/lib/ReviewAppClient.js
@@ -45,7 +45,7 @@ class ReviewAppClient {
     return this._client;
   }
 
-  async _pollOperationStatus(operation) {
+  async _pollOperationStatus(operation, app) {
     if (!operation) {
       return;
     }
@@ -56,11 +56,11 @@ class ReviewAppClient {
         return resolve();
       }
       if (operation.status === 'error') {
-        logger.error({ event: 'review-app-manager', message: operation.error });
+        logger.error({ event: 'review-app-manager', app: app.name, message: operation.error });
         return resolve();
       }
       if (this._pollMaxAttempts && attempts >= this._pollMaxAttempts) {
-        logger.error({ event: 'review-app-manager', message: 'Exceeded max attempts' });
+        logger.error({ event: 'review-app-manager', app: app.name, message: 'Exceeded max attempts' });
         return resolve();
       }
 
@@ -91,7 +91,7 @@ class ReviewAppClient {
 
     try {
       const { operation } = await scalingoClient.Containers.scale(app.name, formation);
-      await this._pollOperationStatus(operation);
+      await this._pollOperationStatus(operation, app);
       logger.ok({ event: 'review-app-manager', app: app.name, message: `App ${app.name} scaled successfully` });
     } catch (err) {
       if ((err._data && err._data.error === 'no change in containers formation') || err === 'no change in containers formation') {

--- a/test/ReviewAppClient.test.js
+++ b/test/ReviewAppClient.test.js
@@ -165,6 +165,7 @@ describe('ReviewAppClient', () => {
       expect(loggerErrorStub.calledOnce).to.be.true;
       expect(loggerErrorStub.firstCall.args[0]).to.deep.equal({
         "event": "review-app-manager",
+        "app": app.name,
         "message":"container web-1 failed to scale"
       });
       scope.isDone();
@@ -199,6 +200,7 @@ describe('ReviewAppClient', () => {
       expect(loggerErrorStub.calledOnce).to.be.true;
       expect(loggerErrorStub.firstCall.args[0]).to.deep.equal({
         "event": "review-app-manager",
+        "app": app.name,
         "message":"Exceeded max attempts"
       });
     });


### PR DESCRIPTION
## 🔆 Problème
Aujourd'hui, nous sommes informés par un message d'erreur lorsqu'une RA n'a pas réussi à démarrer. Cependant, ce message ne mentionne pas l'application Scalingo en question.

## ⛱️ Proposition
Rajouter le nom de l'application dans le message d'erreur.